### PR TITLE
Fix assembler error on armhf

### DIFF
--- a/src/atomic_ptr.hpp
+++ b/src/atomic_ptr.hpp
@@ -132,6 +132,7 @@ namespace xs
                 "1:     ldrex   %1, [%3]\n\t"
                 "       mov     %0, #0\n\t"
                 "       teq     %1, %4\n\t"
+                "       it      eq\n\t"
                 "       strexeq %0, %5, [%3]\n\t"
                 "       teq     %0, #0\n\t"
                 "       bne     1b\n\t"


### PR DESCRIPTION
When compiling for Debian Stretch armhf:
```
  CXX      libxs_la-mailbox.lo
/tmp/ccRX4VuD.s: Assembler messages:
/tmp/ccRX4VuD.s:57: Error: thumb conditional instruction should be in IT block -- `strexeq r7,r0,[r6]'
/tmp/ccRX4VuD.s:190: Error: thumb conditional instruction should be in IT block -- `strexeq r5,r3,[r1]'
/tmp/ccRX4VuD.s:466: Error: thumb conditional instruction should be in IT block -- `strexeq ip,r3,[lr]'
/tmp/ccRX4VuD.s:494: Error: thumb conditional instruction should be in IT block -- `strexeq lr,r5,[r0]'
```
We aren't using libxs much anymore, but for now this is easy enough to fix, just taking the corresponding already-fixed code from ZeroMQ: https://github.com/zeromq/libzmq/blob/master/src/atomic_ptr.hpp#L147-L155

Here's some info on why it requires four if-then instructions: https://stackoverflow.com/questions/34174471/how-can-i-put-thumb-conditional-instruction-into-it-block

Note: aarch64 doesn't generate Thumb instructions or use this code block.
